### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Here's the list of the exposed classes and methods, please review the specific d
 
 Note that:
 
-* Most of the methods take a callback argument that operates on the stream items.
-* The callback, unless it's stated otherwise, will receive an argument with the next chunk.
+* Most of the methods take a Function as argument that operates on the stream items.
+* The Function, unless it's stated otherwise, will receive an argument with the next chunk.
 * If you want to perform your operations asynchronously, return a Promise, otherwise just return the right value.
 
 ## CLI


### PR DESCRIPTION
Remove the Term and Wording CallBack from the README as a Callback is a Final Function that get called after a Function ends This Lib is about FRP Functional Reactiv Programming there the Stream Simply gets a Function and The Result of the Function gets Used in the Same Stream its not the Final Result Like with a Function and a Callback